### PR TITLE
event handler callback signature changed

### DIFF
--- a/test/subscribeWithOptions-spec.js
+++ b/test/subscribeWithOptions-spec.js
@@ -22,7 +22,7 @@ describe('Subscribe with options', function () {
 
   it('should subscribe for events', done => {
 
-    const eventHandler = (err, event, acknowledge) => {
+    const eventHandler = (event) => {
 
       return new Promise((resolve, reject) => {
         console.log('Event:', event);


### PR DESCRIPTION
I used event handler with `(err, event, acknowledge) => {...}` signature in my code and it returned `undefined` for the `event` param.

It seems test was not updated after eventHandler was changed to [return just event object](https://github.com/eventuate-clients/eventuate-client-nodejs/blob/master/src/modules/EventuateClient.js#L372)?
